### PR TITLE
Add date as base node element

### DIFF
--- a/Sources/Node/Convertible/Date+Convertible.swift
+++ b/Sources/Node/Convertible/Date+Convertible.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+extension Date: NodeConvertible {
+    public func makeNode(context: Context = EmptyNode) -> Node {
+        return .date(self)
+    }
+
+    public init(node: Node, in context: Context) throws {
+        guard let date = node.date else {
+            throw NodeError.unableToConvert(node: node, expected: "\(String.self)")
+        }
+        self = date
+    }
+}

--- a/Sources/Node/Core/Node+Init.swift
+++ b/Sources/Node/Core/Node+Init.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 extension Node {
     public init(_ value: Bool) {
         self = .bool(value)
@@ -34,5 +36,9 @@ extension Node {
 
     public init(bytes: [UInt8]) {
         self = .bytes(bytes)
+    }
+    
+    public init(_ date: Date) {
+        self = .date(date)
     }
 }

--- a/Sources/Node/Core/Node+Polymorphic.swift
+++ b/Sources/Node/Core/Node+Polymorphic.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 extension Node: Polymorphic {
     public var string: String? {
         switch self {
@@ -33,6 +35,15 @@ extension Node: Polymorphic {
             return number.uint
         case .bool(let bool):
             return bool ? 1 : 0
+        default:
+            return nil
+        }
+    }
+
+    public var date: Date? {
+        switch self {
+        case .date(let date):
+            return date
         default:
             return nil
         }

--- a/Sources/Node/Core/Node.swift
+++ b/Sources/Node/Core/Node.swift
@@ -2,6 +2,9 @@
     Node is meant to be a transitive data structure that can be used to facilitate conversions
     between different types.
 */
+
+import Foundation
+
 public enum Node {
     case null
     case bool(Bool)
@@ -10,4 +13,5 @@ public enum Node {
     case array([Node])
     case object([String: Node])
     case bytes([UInt8])
+    case date(Date)
 }


### PR DESCRIPTION
I am submitting a series of pull requests to add Date as a class in Node and datetime and timestamp support in Fluent. This allows for full support for time throughout Vapor.

Specifically, there are pull requests for Vapor, Fluent, Node, JSON, MySQL, Leaf, and FluentMySQL
