### PR TITLE
Add Date+Convertible to support using Fluent 1.2 with the new .custom…

### DIFF
--- a/Sources/Node/Convertible/Date+Convertible.swift
+++ b/Sources/Node/Convertible/Date+Convertible.swift
@@ -1,6 +1,13 @@
 import Foundation
 
 extension Date: NodeConvertible {
+    
+    static fileprivate let dateFormatter = { () -> DateFormatter in
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss.ssssss"
+        return dateFormatter
+    }()
+    
     /**
      Turn the Date into a node
      
@@ -8,9 +15,7 @@ extension Date: NodeConvertible {
      - returns: a node if possible
      */
     public func makeNode(context: Context) throws -> Node {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
-        let string = dateFormatter.string(from:self)
+        let string = Date.dateFormatter.string(from:self)
         
         return Node(string)
     }
@@ -26,9 +31,8 @@ extension Date: NodeConvertible {
         
         switch (node) {
         case .string (let string):
-            let dateFormatter = DateFormatter()
-            dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
-            guard let date = dateFormatter.date(from: string) else {
+            
+            guard let date = Date.dateFormatter.date(from: string) else {
                 throw NodeError.unableToConvert(node: node, expected: "\(String.self)")
             }
             self = date

--- a/Sources/Node/Convertible/Date+Convertible.swift
+++ b/Sources/Node/Convertible/Date+Convertible.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+extension Date: NodeConvertible {
+    /**
+     Turn the Date into a node
+     
+     - throws: if convertible can not create a Node
+     - returns: a node if possible
+     */
+    public func makeNode(context: Context) throws -> Node {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        let string = dateFormatter.string(from:self)
+        
+        return Node(string)
+    }
+    
+    /**
+     Initialize the Date with a node within a context.
+     
+     Context is an empty protocol to which any type can conform.
+     This allows flexibility. for objects that might require access
+     to a context outside of the node ecosystem
+     */
+    public init(node: Node, in context: Context) throws {
+        
+        switch (node) {
+        case .string (let string):
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+            guard let date = dateFormatter.date(from: string) else {
+                throw NodeError.unableToConvert(node: node, expected: "\(String.self)")
+            }
+            self = date
+            return
+        default:
+            break
+        }
+        throw NodeError.unableToConvert(node: node, expected: "\(String.self)")
+    }
+}


### PR DESCRIPTION
…(_:type) API with DATETIME and TIMESTAMP as ‘type’.

