### PR TITLE
Date extraction

### DIFF
--- a/Sources/Node/Convertible/Date+Convertible.swift
+++ b/Sources/Node/Convertible/Date+Convertible.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+extension Date: NodeConvertible {
+    public func makeNode(context: Context = EmptyNode) throws -> Node {
+        return .number(.double(self.timeIntervalSince1970))
+    }
+    
+    public init(node: Node, in context: Context) throws {
+        switch node {
+        case .number(let number):
+            self = Date(timeIntervalSince1970: number.double)
+            
+        case .string(let dateString):
+            if let dateMySQL = dateFormatterMySQL.date(from: dateString) {
+                self = dateMySQL
+            } else if let dateRFC1123 = dateFormatterRFC1123.date(from: dateString) {
+                self = dateRFC1123
+            } else {
+                throw NodeError.unableToConvert(
+                    node: node,
+                    expected: "MySQL DATETIME or RFC1123 formatted date."
+                )
+            }
+            
+        default:
+            throw NodeError.unableToConvert(
+                node: node,
+                expected: "\(String.self), \(Int.self) or \(Double.self))"
+            )
+        }
+    }
+}
+
+// DateFormatter init is slow, need to reuse. Reusing two DateFormatters is
+// significantly faster than toggling the formatter's `dateFormat` property.
+// On Linux, toggling is actually slower than initializing DateFormatter.
+private var _dfMySQL: DateFormatter?
+private var dateFormatterMySQL: DateFormatter {
+    if let df = _dfMySQL {
+        return df
+    }
+    
+    let df = DateFormatter()
+    df.timeZone = TimeZone(abbreviation: "UTC")
+    df.dateFormat = "yyyy-MM-dd HH:mm:ss"
+    _dfMySQL = df
+    return df
+}
+
+private var _dfRFC1123: DateFormatter?
+private var dateFormatterRFC1123: DateFormatter {
+    if let df = _dfRFC1123 {
+        return df
+    }
+    
+    let df = DateFormatter()
+    df.dateFormat = "EEE, dd MMM yyyy HH:mm:ss z"
+    _dfRFC1123 = df
+    return df
+}

--- a/Tests/NodeTests/NodeExtractTests.swift
+++ b/Tests/NodeTests/NodeExtractTests.swift
@@ -231,6 +231,18 @@ class NodeExtractTests: XCTestCase {
             XCTFail("should throw node error unable to convert")
         } catch NodeError.unableToConvert {}
     }
+    
+    func testExtractDateRFC1123() throws {
+        let node = Node(["time": "Sun, 16 May 2010 15:20:00 GMT"])
+        let date: Date = try node.extract("time")
+        XCTAssertEqual(date.timeIntervalSince1970, 1274023200.0)
+    }
+    
+    func testExtractDateMySQLDATETIME() throws {
+        let node = Node(["time": "2010-05-16 15:20:00"])
+        let date: Date = try node.extract("time")
+        XCTAssertEqual(date.timeIntervalSince1970, 1274023200.0)
+    }
 }
 
 extension Date {


### PR DESCRIPTION
Conformed `Date` to `NodeConvertible `. At the moment, MySQL DateFormatter is manually set to UTC+0 for the timezone to have the same date input/output as RFC1123. I'm not sure if that is okay or not.

As for the parsable dates, for the beginning I feel like these two would cover most use cases, but if it feels like a lot are missing maybe we could open up some static registry where new date formats could be added by the user and the extraction would try each one. I don't know, just thinking out loud.