### PR TITLE
Descriptive NodeError

### DIFF
--- a/Sources/Node/Convertible/Bool+Convertible.swift
+++ b/Sources/Node/Convertible/Bool+Convertible.swift
@@ -5,7 +5,7 @@ extension Bool: NodeConvertible {
 
     public init(node: Node, in context: Context) throws {
         guard let bool = node.bool else {
-            throw NodeError.unableToConvert(node: node, expected: "\(Bool.self)")
+            throw NodeError.unableToConvert(node: node, expected: "\(Bool.self)", key: nil)
         }
         self = bool
     }

--- a/Sources/Node/Convertible/FloatingPoint+Convertible.swift
+++ b/Sources/Node/Convertible/FloatingPoint+Convertible.swift
@@ -22,7 +22,7 @@ extension NodeConvertibleFloatingPointType {
 
     public init(node: Node, in context: Context) throws {
         guard let double = node.double else {
-            throw NodeError.unableToConvert(node: node, expected: "\(Self.self)")
+            throw NodeError.unableToConvert(node: node, expected: "\(Self.self)", key: nil)
         }
         self.init(double)
     }

--- a/Sources/Node/Convertible/Integer+Convertible.swift
+++ b/Sources/Node/Convertible/Integer+Convertible.swift
@@ -12,7 +12,7 @@ extension SignedInteger {
 
     public init(node: Node, in context: Context) throws {
         guard let int = node.int else {
-            throw NodeError.unableToConvert(node: node, expected: "\(Self.self)")
+            throw NodeError.unableToConvert(node: node, expected: "\(Self.self)", key: nil)
         }
 
         self.init(int.toIntMax())

--- a/Sources/Node/Convertible/Sequence+Convertible.swift
+++ b/Sources/Node/Convertible/Sequence+Convertible.swift
@@ -89,7 +89,7 @@ extension KeyAccessible where Key == String, Value: NodeInitializable {
     public init(node: NodeRepresentable, in context: Context = EmptyNode) throws {
         let node = try node.makeNode(context: context)
         guard let object = node.nodeObject else {
-            throw NodeError.unableToConvert(node: node, expected: "\([Key: Value].self)")
+            throw NodeError.unableToConvert(node: node, expected: "\([Key: Value].self)", key: nil)
         }
 
         var mapped: [String: Value] = [:]

--- a/Sources/Node/Convertible/String+Convertible.swift
+++ b/Sources/Node/Convertible/String+Convertible.swift
@@ -5,7 +5,7 @@ extension String: NodeConvertible {
 
     public init(node: Node, in context: Context) throws {
         guard let string = node.string else {
-            throw NodeError.unableToConvert(node: node, expected: "\(String.self)")
+            throw NodeError.unableToConvert(node: node, expected: "\(String.self)", key: nil)
         }
         self = string
     }

--- a/Sources/Node/Convertible/UnsignedInteger+Convertible.swift
+++ b/Sources/Node/Convertible/UnsignedInteger+Convertible.swift
@@ -12,7 +12,7 @@ extension UnsignedInteger {
 
     public init(node: Node, in context: Context) throws {
         guard let int = node.uint else {
-            throw NodeError.unableToConvert(node: node, expected: "\(Self.self)")
+            throw NodeError.unableToConvert(node: node, expected: "\(Self.self)", key: nil)
         }
 
         self.init(int.toUIntMax())

--- a/Sources/Node/Extract/Node+Extract.swift
+++ b/Sources/Node/Extract/Node+Extract.swift
@@ -40,7 +40,7 @@ extension NodeBacked {
         transform: (InputType) throws -> T)
         throws -> T {
             guard let value = node[path] else {
-                throw NodeError.unableToConvert(node: nil, expected: "\(T.self)")
+                throw NodeError.unableToConvert(node: nil, expected: "\(T.self)", key: path)
             }
 
             let input = try InputType(node: value)
@@ -75,7 +75,7 @@ extension NodeBacked {
         _ path: [PathIndex])
         throws -> T {
             guard let value = node[path] else {
-                throw NodeError.unableToConvert(node: nil, expected: "\(T.self)")
+                throw NodeError.unableToConvert(node: nil, expected: "\(T.self)", key: path)
             }
             return try T(node: value)
     }
@@ -90,7 +90,7 @@ extension NodeBacked {
         _ path: [PathIndex])
         throws -> [T] {
             guard let value = node[path] else {
-                throw NodeError.unableToConvert(node: nil, expected: "\([T].self)")
+                throw NodeError.unableToConvert(node: nil, expected: "\([T].self)", key: path)
             }
             return try [T](node: value)
     }
@@ -105,7 +105,7 @@ extension NodeBacked {
         _ path: [PathIndex])
         throws -> [[T]] {
             guard let initial = node[path] else {
-                throw NodeError.unableToConvert(node: nil, expected: "\([[T]].self)")
+                throw NodeError.unableToConvert(node: nil, expected: "\([[T]].self)", key: path)
             }
             let array = initial.nodeArray ?? [initial]
             return try array.map { try [T](node: $0) }
@@ -122,7 +122,7 @@ extension NodeBacked {
         throws -> [String : T] {
             let value = node[path]
             guard let object = value?.nodeObject else {
-                throw NodeError.unableToConvert(node: value, expected: "\([String: T].self)")
+                throw NodeError.unableToConvert(node: value, expected: "\([String: T].self)", key: path)
             }
             return try object.mapValues { return try T(node: $0) }
     }
@@ -138,7 +138,7 @@ extension NodeBacked {
         throws -> [String : [T]] {
             let value = node[path]
             guard let object = value?.nodeObject else {
-                throw NodeError.unableToConvert(node: value, expected: "\([String: [T]].self)")
+                throw NodeError.unableToConvert(node: value, expected: "\([String: [T]].self)", key: path)
             }
             return try object.mapValues { return try [T](node: $0) }
     }
@@ -153,7 +153,7 @@ extension NodeBacked {
         _ path: [PathIndex])
         throws -> Set<T> {
             guard let value = node[path] else {
-                throw NodeError.unableToConvert(node: nil, expected: "\(Set<T>.self)")
+                throw NodeError.unableToConvert(node: nil, expected: "\(Set<T>.self)", key: path)
             }
             let array = try [T](node: value)
             return Set(array)
@@ -214,7 +214,7 @@ extension NodeBacked {
         throws -> [String : T]? {
             guard let node = node[path], node != .null else { return nil }
             guard let object = node.nodeObject else {
-                throw NodeError.unableToConvert(node: node, expected: "\([String: T].self)")
+                throw NodeError.unableToConvert(node: node, expected: "\([String: T].self)", key: path)
             }
             return try object.mapValues { return try T(node: $0) }
     }
@@ -230,7 +230,7 @@ extension NodeBacked {
         throws -> [String : [T]]? {
             guard let node = node[path], node != .null else { return nil }
             guard let object = node.nodeObject else {
-                throw NodeError.unableToConvert(node: node, expected: "\([String: [T]].self)")
+                throw NodeError.unableToConvert(node: node, expected: "\([String: [T]].self)", key: path)
             }
             return try object.mapValues { return try [T](node: $0) }
     }

--- a/Sources/Node/Utilities/Errors.swift
+++ b/Sources/Node/Utilities/Errors.swift
@@ -5,5 +5,16 @@ public enum NodeError: Swift.Error {
         - param node: the node that was unable to convert
         - param expected: a description of the type Genome was trying to convert to
     */
-    case unableToConvert(node: Node?, expected: String)
+    case unableToConvert(node: Node?, expected: String, key: [PathIndex]?)
+    
+    var localizedDescription: String {
+        switch self {
+        case let .unableToConvert(node, expected, key):
+            if let key = key {
+                return "Expected \(expected) \(key.map { $0.string }) to be found on \(node?.string ?? "node")."
+            } else {
+                return "unableToConvert(\(node), expected: \(expected))"
+            }
+        }
+    }
 }


### PR DESCRIPTION
Extend NodeError.unableToConvert to include description of which field that was accessed.

When a user tells you that the server is returning `unableToConvert(Optional(Node.Node.null), "String")`, it makes it very hard to debug the problem without fully reproducing it. This attempts to fix this by adding a better description of what key on the node that was accessed, allowing the developer to find the offending field right away.

Depends on https://github.com/vapor/path-indexable/pull/9