### PR TITLE
add descriptions explicit for 3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ Carthage/Build
 .build/
 Packages/
 *.xcodeproj
+Package.pins

--- a/Sources/Node/Core/Node.swift
+++ b/Sources/Node/Core/Node.swift
@@ -14,3 +14,28 @@ public enum Node {
     case bytes([UInt8])
     case date(Date)
 }
+
+extension Node: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .null:
+            return "null"
+        case .bool(let bool):
+            return bool.description
+        case .number(let number):
+            return number.description
+        case .string(let string):
+            return string.description
+        case .array(let array):
+            let string = array.map { $0.description } .joined(separator: ", ")
+            return "[\(string)]"
+        case .object(let ob):
+            let string =  ob.map { key, value in "\(key): \(value)" } .joined(separator: ", ")
+            return "[\(string)]"
+        case .bytes(let bytes):
+            return "\(bytes)"
+        case .date(let date):
+            return "\(date)"
+        }
+    }
+}

--- a/Sources/Node/Utilities/Errors.swift
+++ b/Sources/Node/Utilities/Errors.swift
@@ -12,6 +12,6 @@ extension NodeError {
 
 extension NodeError: CustomStringConvertible {
     public var description: String {
-        return "Expected \(expectation)\nGot: \(node)\nKey: \(key)"
+        return "Expected \(expectation)\nGot: \(node ?? .null)\nKey: \(key ?? [])"
     }
 }

--- a/Sources/Node/Utilities/Errors.swift
+++ b/Sources/Node/Utilities/Errors.swift
@@ -12,6 +12,6 @@ extension NodeError {
 
 extension NodeError: CustomStringConvertible {
     public var description: String {
-        return "Expected \(expectation)\nGot: \(node ?? .null)\nKey: \(key ?? [])"
+        return "Expected \(expectation) Got: \(node ?? .null) forKey: \(key ?? [])"
     }
 }


### PR DESCRIPTION
For consideration:

right now, this logs a Node.bool(true) as `true`, should it log as `Node.bool(true)`? to be more explicit about typing?