### PR TITLE
Update Date+Convertible.swift

### DIFF
--- a/Sources/Node/Convertibles/Date+Convertible.swift
+++ b/Sources/Node/Convertibles/Date+Convertible.swift
@@ -103,7 +103,7 @@ extension DateFormatter {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.timeZone = TimeZone(secondsFromGMT: 0)
-        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX"
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
         return formatter
     }()
 }


### PR DESCRIPTION
The milliseconds here are causing Swift 4's json decoding to break when using `decoder.dateDecodingStrategy = .iso8601`.  Note: I don't see any mention of milliseconds on iso8601's wikipedia page.  https://en.wikipedia.org/wiki/ISO_8601

Opening PR for discussion.