### PR TITLE
Add NodeConvertible conformance to IUOs

### DIFF
--- a/Sources/Node/Fuzzy/Optional+Convertible.swift
+++ b/Sources/Node/Fuzzy/Optional+Convertible.swift
@@ -18,3 +18,25 @@ extension Optional: NodeConvertible {
         }
     }
 }
+
+extension ImplicitlyUnwrappedOptional: NodeConvertible {
+    public init(node: Node) throws {
+        guard node != .null else {
+            self = .none
+            return
+        }
+
+        let wrapped: Wrapped = try Node.fuzzy.initialize(node: node)
+        self = .some(wrapped)
+    }
+
+    public func makeNode(in context: Context?) throws -> Node {
+        switch self {
+        case .none:
+            return .null
+        case .some(let some):
+            return try Node.fuzzy.represent(some, in: context)
+        }
+    }
+}
+

--- a/Tests/NodeTests/NodeGetterTests.swift
+++ b/Tests/NodeTests/NodeGetterTests.swift
@@ -61,6 +61,10 @@ class NodeGetterTests: XCTestCase {
         ("testgetSetThrows", testgetSetThrows),
         ("testgetDateRFC1123", testgetDateRFC1123),
         ("testgetDateMySQLDATETIME", testgetDateMySQLDATETIME),
+        ("testgetOptionalDateRFC1123", testgetOptionalDateRFC1123),
+        ("testgetOptionalDateNil", testgetOptionalDateNil),
+        ("testgetImplicitlyUnwrappedOptionalDateRFC1123", testgetImplicitlyUnwrappedOptionalDateRFC1123),
+        ("testgetImplicitlyUnwrappedOptionalDateNil", testgetImplicitlyUnwrappedOptionalDateNil),
         ("testBadObject", testBadObject),
     ]
 
@@ -257,6 +261,30 @@ class NodeGetterTests: XCTestCase {
         let node = try Node(node: ["time": "2010-05-16 15:20:00"])
         let date: Date = try node.get("time")
         XCTAssertEqual(date.timeIntervalSince1970, 1274023200.0)
+    }
+
+    func testgetOptionalDateRFC1123() throws {
+        let node = try Node(node: ["time": "Sun, 16 May 2010 15:20:00 GMT"])
+        let date: Date? = try node.get("time")
+        XCTAssertEqual(date?.timeIntervalSince1970, 1274023200.0)
+    }
+
+    func testgetImplicitlyUnwrappedOptionalDateRFC1123() throws {
+        let node = try Node(node: ["time": "Sun, 16 May 2010 15:20:00 GMT"])
+        let date: Date! = try node.get("time")
+        XCTAssertEqual(date.timeIntervalSince1970, 1274023200.0)
+    }
+
+    func testgetOptionalDateNil() throws {
+        let node = Node.null
+        let date: Date? = try node.get("time")
+        XCTAssertNil(date)
+    }
+
+    func testgetImplicitlyUnwrappedOptionalDateNil() throws {
+        let node = Node.null
+        let date: Date! = try node.get("time")
+        XCTAssertNil(date)
     }
 
     func testBadObject() throws {


### PR DESCRIPTION
Currently, using the fuzzy `get` function works for regular optional types, but fails with a non-friendly [error](https://qutheory.slackarchive.io/help/page-100/ts-1514276936000150) thrown for implicitly unwrapped optionals, despite the two being almost completely identical types.

This PR resolves this error family with a single stroke of the copy-paste brush.
