### PR TITLE
[WIP] Conform StructuredData(Wrapper) to Encodable

### DIFF
--- a/Sources/Node/StructuredData/StructuredData+Encodable.swift
+++ b/Sources/Node/StructuredData/StructuredData+Encodable.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+#if swift(>=4.0)
+private enum UniversalCodingKey: CodingKey {
+    case int(Int)
+    case string(String)
+
+    init?(intValue: Int) {
+        self = .int(intValue)
+    }
+
+    init?(stringValue: String) {
+        self = .string(stringValue)
+    }
+
+    var intValue: Int? {
+        guard case .int(let intValue) = self else {
+            return nil
+        }
+
+        return intValue
+    }
+
+    var stringValue: String {
+        switch self {
+        case .string(let string):
+            return string
+        case .int(let int):
+            return int.description
+        }
+    }
+}
+
+extension StructuredData: Encodable {
+    public func encode(to encoder: Encoder) throws {
+        switch self {
+        case .array(let array):
+            var container = encoder.unkeyedContainer()
+            try container.encode(contentsOf: array)
+        case .bool(let bool):
+            var container = encoder.singleValueContainer()
+            try container.encode(bool)
+        case .bytes(let bytes):
+            var container = encoder.singleValueContainer()
+            try container.encode(Data(bytes))
+        case .date(let date):
+            var container = encoder.singleValueContainer()
+            try container.encode(date)
+        case .null:
+            var container = encoder.singleValueContainer()
+            try container.encodeNil()
+        case .number(let number):
+            var container = encoder.singleValueContainer()
+
+            switch number {
+            case .double(let double):
+                try container.encode(double)
+            case .int(let int):
+                try container.encode(int)
+            case .uint(let uint):
+                try container.encode(uint)
+            }
+        case .object(let object):
+            var container = encoder.container(keyedBy: UniversalCodingKey.self)
+            try object.forEach {
+                try container.encode($1, forKey: UniversalCodingKey.string($0))
+            }
+        case .string(let string):
+            var container = encoder.singleValueContainer()
+            try container.encode(string)
+        }
+    }
+}
+#endif

--- a/Sources/Node/StructuredDataWrapper/StructuredDataWrapper.swift
+++ b/Sources/Node/StructuredDataWrapper/StructuredDataWrapper.swift
@@ -1,3 +1,34 @@
+#if swift(>=4.0)
+import Foundation
+
+public protocol StructuredDataWrapper:
+    NodeConvertible,
+    PathIndexable,
+    Equatable,
+    ExpressibleByNilLiteral,
+    ExpressibleByBooleanLiteral,
+    ExpressibleByIntegerLiteral,
+    ExpressibleByFloatLiteral,
+    ExpressibleByStringLiteral,
+    ExpressibleByArrayLiteral,
+    ExpressibleByDictionaryLiteral,
+    Encodable
+{
+    static var defaultContext: Context? { get }
+
+    var wrapped: StructuredData { get set }
+    var context: Context { get }
+    init(_ wrapped: StructuredData, in context: Context?)
+}
+
+extension StructuredDataWrapper { // : Encodable
+    public func encode(to encoder: Encoder) throws {
+        try wrapped.encode(to: encoder)
+    }
+}
+
+#else
+
 public protocol StructuredDataWrapper:
     NodeConvertible,
     PathIndexable,
@@ -16,6 +47,7 @@ public protocol StructuredDataWrapper:
     var context: Context { get }
     init(_ wrapped: StructuredData, in context: Context?)
 }
+#endif
 
 extension StructuredDataWrapper {
     public static var defaultContext: Context? { return nil }


### PR DESCRIPTION
This is a work-in-progress PR that will hopefully open a whole new ~can of worms~ world of possibilities for interfacing parts of Vapor 2 with modern JSON.

By automatically complying StructuredData and StructuredDataWrapper to Encodable, a few new scenarios become possible:
- If a Fluent Model is manually conformed to Encodable, the `id` field can be directly encoded.
- The results of a raw query can be returned "directly" from a route, passed to MongoKitten, etc.
- ???
- PROFIT!

TODO: tests, think about the opposite direction, and maybe figure out a few more ways to use this power.